### PR TITLE
Fix rbenv gem version comparison

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ charset = utf-8
 insert_final_newline = true
 
 [*.{sh,erb,rb,php}]
-indent_style = tab
+indent_style = space
 
 [*.pp]
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# http://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+
+[*.{sh,erb,rb,php}]
+indent_style = tab
+
+[*.pp]
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ Specifically, `pluginsync` must be enabled in puppet.conf configuration file on 
 pluginsync = true
 ```
 
+## Testing
+
+You can use the Puppet logger to output information within the `Puppet::Type` definitions. For example: `Puppet.info("current = #{current}, provider.current = #{provider.current}, requested = #{requested}, provider.latest = #{provider.latest}, self = #{self}, @should = #{@should}")`.
+
 ## Supported Platforms
 
 * CentOS

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ pluginsync = true
 
 ## Testing
 
-You can use the Puppet logger to output information within the `Puppet::Type` definitions. For example: `Puppet.info("current = #{current}, provider.current = #{provider.current}, requested = #{requested}, provider.latest = #{provider.latest}, self = #{self}, @should = #{@should}")`.
+You can use the Puppet logger to output information within the `Puppet::Type` definitions. For example: `Puppet.info("message here")`.
 
 ## Supported Platforms
 

--- a/lib/puppet/provider/rbenvgem/default.rb
+++ b/lib/puppet/provider/rbenvgem/default.rb
@@ -28,18 +28,18 @@ Puppet::Type.type(:rbenvgem).provide :default do
   def versions(where = :local)
     args = ['list', where == :remote ? '--remote' : '--local', "^#{gem_name}$"]
 
-		versions = []
-		gem(*args).lines.map do |line|
-			matches = line.match(/^(?:\S+)\s+\((.+)\)/)
-			next unless matches
-	    versions += matches[1].split(/,\s*/)
-		end
-		versions.uniq
-	end
+    versions = []
+    gem(*args).lines.map do |line|
+      matches = line.match(/^(?:\S+)\s+\((.+)\)/)
+      next unless matches
+      versions += matches[1].split(/,\s*/)
+    end
+    versions.uniq
+  end
 
-	def gem_name
-		resource[:gemname]
-	end
+  def gem_name
+    resource[:gemname]
+  end
 
   private
     # Executes a gem command

--- a/lib/puppet/type/rbenvgem.rb
+++ b/lib/puppet/type/rbenvgem.rb
@@ -35,8 +35,8 @@ Puppet::Type.newtype(:rbenvgem) do
       case requested
         when :present, :installed
           current != :absent
-				when :latest
-					versions.include?(provider.latest)
+        when :latest
+          versions.include?(provider.latest)
         when :absent
           current == :absent
         when /^['"]([^\s])\s([\d\.]+)['"]$/ # e.g. "'< 2.0'", "'>= 0.4.3'"

--- a/lib/puppet/type/rbenvgem.rb
+++ b/lib/puppet/type/rbenvgem.rb
@@ -1,3 +1,5 @@
+# https://docs.puppet.com/guides/custom_types.html
+# https://www.safaribooksonline.com/library/view/puppet-types-and/9781449339319/ch04.html
 Puppet::Type.newtype(:rbenvgem) do
   desc 'A Ruby Gem installed inside an rbenv-installed Ruby'
 
@@ -23,18 +25,27 @@ Puppet::Type.newtype(:rbenvgem) do
       provider.current || :absent
     end
 
+    # +current+ The most recent version installed
     def insync?(current)
       requested = @should.first
+      versions = provider.versions
+
+      Puppet.debug("rbenvgem - #{provider.gem_name}: current = #{current}, requested = #{requested}, provider.latest = #{provider.latest}, versions = #{versions.inspect}")
 
       case requested
-      when :present, :installed
-        current != :absent
-      when :latest
-        current == provider.latest
-      when :absent
-        current == :absent
-      else
-        current == [requested]
+        when :present, :installed
+          current != :absent
+				when :latest
+					versions.include?(provider.latest)
+        when :absent
+          current == :absent
+        when /^['"]([^\s])\s([\d\.]+)['"]$/ # e.g. "'< 2.0'", "'>= 0.4.3'"
+          operand = $LAST_MATCH_INFO[1]
+          requested_version = $LAST_MATCH_INFO[2]
+          Puppet.debug("rbenvgem - #{provider.gem_name}: evaluating #{"'#{current}' #{operand} '#{requested_version}'"}")
+          eval("'#{current}' #{operand} '#{requested_version}'")
+        else
+          versions.include?(requested)
       end
     end
   end

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -34,7 +34,18 @@ define rbenv::plugin(
     creates => $destination,
     path    => ['/bin', '/usr/bin', '/usr/sbin'],
     timeout => $timeout,
-    cwd => $home_path,
+    cwd     => $home_path,
     require => File["rbenv::plugins ${user}"],
+  }
+
+  exec { "rbenv::plugin::update ${user} ${plugin_name}":
+    command => 'git pull',
+    user    => $user,
+    group   => $group,
+    path    => ['/bin', '/usr/bin', '/usr/sbin'],
+    timeout => $timeout,
+    cwd     => $destination,
+    require => Exec["rbenv::plugin::checkout ${user} ${plugin_name}"],
+    onlyif  => 'git remote update; if [ "$(git rev-parse @{0})" = "$(git rev-parse @{u})" ]; then return 0; else return 1; fi ]',
   }
 }

--- a/spec/defines/rbenv__plugin_spec.rb
+++ b/spec/defines/rbenv__plugin_spec.rb
@@ -26,7 +26,10 @@ describe 'rbenv::plugin', :type => :define do
       :user    => user,
       :cwd     => target_path,
       :require => /rbenv::plugin::checkout #{user} #{plugin_name}/,
-      :path    => ['/bin','/usr/bin','/usr/sbin']
+      :path    => ['/bin','/usr/bin','/usr/sbin'],
+      :onlyif  => 'git remote update; ' \
+                  'if [ "$(git rev-parse @{0})" = "$(git rev-parse @{u})" ]; ' \
+                  'then return 0; else return 1; fi ]'
     )
   end
 


### PR DESCRIPTION
This branch provides fixes for comparison of requested and current versions of rubygems. Previously, requested versions of `'< 2.0'` or `'>= 1.0.1'` would not be correctly determine and would require a re-installation of the gem. 

In addition, the request of `:latest` would also correctly work due to how `gem list` was being used. This restricts the `gem list` command to only find gems with the exact name rather than one that ended with the name which was causing additional gem versions to be included in the comparison. For example, the gem versions for `crack` were being included in gem versions for `rack`. 

The provider also exposes the full array of installed versions to the type for use within `insync?`. `insync?` now looks to check if the requested version is in the list of versions installed rather than just look at the latest version. This should allow lower versioned gems to be included even if there is a higher version installed.

I attempted to get unit testing setup for the custom provider [as is detailed here](http://linuxsimba.com/testing-puppet-custom-type) but was unsuccessful. 
